### PR TITLE
Use lobject for zsums

### DIFF
--- a/mb/mb/hashes.py
+++ b/mb/mb/hashes.py
@@ -70,53 +70,97 @@ class Hasheable:
 
         for performance, this function talks very low level to the database"""
         # get a database cursor, but make it persistent which is faster
-        try:
-            conn.mycursor
-        except AttributeError:
-            conn.mycursor = conn.Files._connection.getConnection().cursor()
-        c = conn.mycursor
+        with conn.Files._connection.getConnection() as _conn:
+            _conn.set_session(autocommit=False)
+            with _conn.cursor() as c:
 
-        c.execute("SELECT id, mtime, size FROM files WHERE path = %s LIMIT 1",
-                  [self.src_rel])
-        res_file = c.fetchone()
-        if res_file:
-            file_id = res_file[0]
-            res_hash = res_file
-        else:
-            print('File %r not in database. Will be inserted.' % self.src_rel)
-            file_id = None
-            res_hash = None
-
-        if not res_file:
-            c.execute("INSERT INTO files (path) VALUES (%s)",
+                c.execute("SELECT id, mtime, size FROM files WHERE path = %s LIMIT 1",
                       [self.src_rel])
-            if not self.skip_metadata:
-                c.execute("SELECT currval('files_id_seq')")
-                file_id = c.fetchone()[0]
-
-        if self.skip_metadata:
-            return
-
-        if self.hb.chunk_size == 0 or (self.size + self.hb.chunk_size - 1) / (self.hb.chunk_size - 1) != len(self.hb.pieceshex):
-            self.hb.zsyncpieceshex = []
-
-        if not res_hash:
+                res_file = c.fetchone()
+                if res_file:
+                    file_id = res_file[0]
+                    res_hash = res_file
+                else:
+                    print('File %r not in database. Will be inserted.' % self.src_rel)
+                    file_id = None
+                    res_hash = None
 
             if dry_run:
                 print('Would create hashes in db for: ', self.src_rel)
                 return
 
+            def batch(iterable, n=1):
+                l = len(iterable)
+                for ndx in range(0, l, n):
+                    yield iterable[ndx:min(ndx + n, l)]
+
+            lobj = None
+            with _conn.cursor() as cur:
+                if not res_file:
+                    cur.execute("INSERT INTO files (path) VALUES (%s)",
+                          [self.src_rel])
+                    if not self.skip_metadata:
+                        cur.execute("SELECT currval('files_id_seq')")
+                        file_id = cur.fetchone()[0]
+
+            if self.skip_metadata:
+                return
+
+            if self.hb.chunk_size == 0 or (self.size + self.hb.chunk_size - 1) / (self.hb.chunk_size - 1) != len(self.hb.pieceshex):
+                self.hb.zsyncpieceshex = []
+
+            if res_hash:
+                 mtime, size = res_hash[1], res_hash[2]
+
+                 if int(self.mtime) == mtime and self.size == size and not force:
+                    if verbose:
+                        print('Up to date in db: %r' % self.src_rel)
+                    return
+
             if self.hb.empty:
                 self.hb.fill(verbose=verbose)
+
             if self.hb.empty:
                 sys.stderr.write('skipping db hash generation\n')
                 return
 
-            zsums = ''
-            for i in self.hb.zsums:
-                zsums = zsums + i.hexdigest()
+            if self.hb.zsums:
+                import psycopg2
+                import psycopg2.extensions
+                # zsums can be big for large files, so use postgres large object
+                # this object is planned to live only inside transaction
+                lobj = cur.connection.lobject(0,'w')
+                for i in batch(self.hb.zsums, 1024):
+                    lobj.write(b''.join([j for j in i]))
 
-            c.execute("""UPDATE files SET 
+            with _conn.cursor() as cur:
+                if lobj is None:
+                    cur.execute("""UPDATE files SET 
+                            mtime  = to_timestamp(%s), 
+                            size   = %s, 
+                            md5    = %s,
+                            sha1   = decode(%s, 'hex'), 
+                            sha256 = decode(%s, 'hex'), 
+                            sha1piecesize = %s,
+                            sha1pieces = decode(%s, 'hex'),
+                            btih = decode(%s, 'hex'),
+                            pgp = %s, 
+                            zblocksize = NULL,
+                            zhashlens = NULL, 
+                            zsums = NULL
+                       WHERE id = %s""",
+                      [int(self.mtime), self.size,
+                       self.hb.md5hex or '',
+                       self.hb.sha1hex or '',
+                       self.hb.sha256hex or '',
+                       self.hb.chunk_size,
+                       ''.join(self.hb.pieceshex) +
+                       ''.join(self.hb.zsyncpieceshex),
+                       self.hb.btihhex or '',
+                       self.hb.pgp or '',
+                       file_id]);
+                else:
+                    cur.execute("""UPDATE files SET 
                             mtime  = to_timestamp(%s), 
                             size   = %s, 
                             md5    = %s,
@@ -128,7 +172,7 @@ class Hasheable:
                             pgp = %s, 
                             zblocksize = %s,
                             zhashlens = %s, 
-                            zsums = decode(%s, 'hex')
+                            zsums = lo_get(%s)
                        WHERE id = %s""",
                       [int(self.mtime), self.size,
                        self.hb.md5hex or '',
@@ -141,51 +185,9 @@ class Hasheable:
                        self.hb.pgp or '',
                        self.hb.zblocksize,
                        self.hb.get_zparams(),
-                       zsums,
-                       file_id]
-                      )
-            if verbose:
-                print('Hash was not present yet in database - inserted')
-        else:
-            mtime, size = res_hash[1], res_hash[2]
-
-            if int(self.mtime) == mtime and self.size == size and not force:
-                if verbose:
-                    print('Up to date in db: %r' % self.src_rel)
-                return
-
-            if self.hb.empty:
-                self.hb.fill(verbose=verbose)
-            if self.hb.empty:
-                sys.stderr.write('skipping db hash generation\n')
-                return
-
-            zsums = ''
-            for i in self.hb.zsums:
-                zsums = zsums + i.hexdigest()
-
-            c.execute("""UPDATE files set mtime = to_timestamp(%s), size = %s,
-                                         md5 = decode(%s, 'hex'),
-                                         sha1 = decode(%s, 'hex'),
-                                         sha256 = decode(%s, 'hex'),
-                                         sha1piecesize = %s,
-                                         sha1pieces = decode(%s, 'hex'),
-                                         btih = decode(%s, 'hex'),
-                                         pgp = %s,
-                                         zblocksize = %s,
-                                         zhashlens = %s,
-                                         zsums = decode(%s, 'hex')
-                         WHERE id = %s""",
-                      [int(self.mtime), self.size,
-                       self.hb.md5hex or '', self.hb.sha1hex or '', self.hb.sha256hex or '',
-                       self.hb.chunk_size, ''.join(
-                           self.hb.pieceshex) + ''.join(self.hb.zsyncpieceshex),
-                       self.hb.btihhex or '',
-                       self.hb.pgp or '',
-                       self.hb.zblocksize,
-                       self.hb.get_zparams(),
-                       zsums,
-                       file_id])
+                       lobj.oid,
+                       file_id]);
+                    lobj.unlink()
             if verbose:
                 print('Hash updated in database for %r' % self.src_rel)
 
@@ -382,13 +384,14 @@ class HashBag:
 
             # padding
             if len(block) < self.zblocksize:
-                block = block + ('\x00' * (self.zblocksize - len(block)))
+                block = block + (b'\x00' * (self.zblocksize - len(block)))
 
             md4 = hashlib.new('md4')
             md4.update(block)
             c = md4.digest()
 
             if self.do_zsync_hashes:
+                import zsync
                 r = zsync.rsum06(block)
 
                 # save only some trailing bytes
@@ -398,7 +401,7 @@ class HashBag:
 
     def get_zsync_digest(self, buf, blocksize):
         if len(buf) < blocksize:
-            buf = buf + ('\x00' * (blocksize - len(buf)))
+            buf = buf + (b'\x00' * (blocksize - len(buf)))
         r = zsync.rsum06(buf)
         return "%02x%02x%02x%02x" % (ord(r[3]), ord(r[2]), ord(r[1]), ord(r[0]))
 

--- a/t/docker/environs/01-smoke.sh
+++ b/t/docker/environs/01-smoke.sh
@@ -23,11 +23,11 @@ for x in ap7 ap8 ap9; do
     echo $xx/dt/downloads/{folder1,folder2,folder3}/{file1,file2}.dat | xargs -n 1 touch
 done
 
-mb9*/mb.sh makehashes $PWD/ap9-system2/dt
+mb9*/mb.sh makehashes -v $PWD/ap9-system2/dt
 
 ap9*/start.sh
 
-mb9*/mb.sh makehashes $PWD/ap9-system2/dt
+mb9*/mb.sh makehashes -v $PWD/ap9-system2/dt
 
 ap9*/curl.sh downloads/ | grep folder1
 

--- a/t/docker/environs/07-zsync-full.sh
+++ b/t/docker/environs/07-zsync-full.sh
@@ -1,0 +1,48 @@
+#!../lib/test-in-container-environs.sh
+set -ex
+
+./environ.sh pg9-system2
+./environ.sh ap9-system2
+./environ.sh ap8-system2
+./environ.sh ap7-system2
+./environ.sh mb9 $(pwd)/mirrorbrain
+
+pg9*/start.sh
+
+mb9*/configure_db.sh pg9
+mb9*/configure_apache.sh ap9
+
+size=${BIG_FILE_SIZE:-100M}
+file=.product/mb/.data/file$size
+
+mkdir -p .product/mb/.data
+[ -f $file ] || ! which fallocate || fallocate -l $size $file
+[ -f $file ] || dd if=/dev/zero of=./$file bs=4K iflag=fullblock,count_bytes count=$size
+
+sed -i '/dbname = mirrorbrain/a zsync_hashes = 1' mb9*/mirrorbrain.conf
+
+ap9=$(ls -d ap9*)
+
+# populate test data
+for x in ap7 ap8 ap9; do
+    xx=$(ls -d $x*/)
+    mkdir -p $xx/dt/downloads/
+    # add the file only to one mirror
+    [ $x == ap7 ] || ln $file $xx/dt/downloads/
+done
+
+mb9*/mb.sh makehashes -v $PWD/ap9-system2/dt/
+
+for x in ap7 ap8; do
+    $x*/start.sh
+    $x*/status.sh
+    mb9*/mb.sh new $x --http http://"$($x-system2/print_address.sh)" --region NA --country us
+    mb9*/mb.sh scan --enable $x
+done
+
+ap9*/start.sh
+checksum=$(ap9*/curl.sh downloads/file$size.zsync | tail -n +4 | md5sum -)
+# compare to checksum, which should be correct one for the file
+[ $size != 100M ] || test "$checksum" == "d0e0f1362080c568137254d190ba2421  -"
+
+tail ap9*/dt/error_log | grep 'Found 1 mirror'

--- a/t/docker/environs/07-zsync.sh
+++ b/t/docker/environs/07-zsync.sh
@@ -21,5 +21,7 @@ ln $file mb9/downloads/
 
 sed -i '/dbname = mirrorbrain/a zsync_hashes = 1' mb9*/mirrorbrain.conf
 
-mb9*/mb.sh makehashes -v $PWD/mb9/downloads
+mb9*/mb.sh makehashes $PWD/mb9/downloads
+# test with checksum of zsums receved for 100M empty file with 2.19.3
+test $file != .product/mb/.data/file100M || test 336c175872f11712eaa1f7a97d8942ab == $(pg9*/sql.sh -t -c "select md5(zsums) from files" mirrorbrain)
 pg9*/sql.sh -c "select sha1, zblocksize, zhashlens, length(zsums) from files" mirrorbrain

--- a/t/docker/environs/07-zsync.sh
+++ b/t/docker/environs/07-zsync.sh
@@ -1,0 +1,25 @@
+#!../lib/test-in-container-environs.sh
+set -ex
+
+./environ.sh mb9 $(pwd)/mirrorbrain
+./environ.sh pg9-system2
+
+pg9*/start.sh
+
+mb9*/configure_db.sh pg9
+
+size=${BIG_FILE_SIZE:-100M}
+file=.product/mb/.data/file$size
+
+mkdir -p .product/mb/.data
+[ -f $file ] || ! which fallocate || fallocate -l $size $file
+[ -f $file ] || dd if=/dev/zero of=./$file bs=4K iflag=fullblock,count_bytes count=$size
+
+mkdir -p mb9/downloads
+
+ln $file mb9/downloads/
+
+sed -i '/dbname = mirrorbrain/a zsync_hashes = 1' mb9*/mirrorbrain.conf
+
+mb9*/mb.sh makehashes -v $PWD/mb9/downloads
+pg9*/sql.sh -c "select sha1, zblocksize, zhashlens, length(zsums) from files" mirrorbrain

--- a/t/docker/lib/Dockerfile.environs
+++ b/t/docker/lib/Dockerfile.environs
@@ -7,6 +7,9 @@ ENV LANG en_US.UTF-8
 RUN zypper -n install git-core wget tar m4
 WORKDIR /opt
 RUN git clone https://github.com/andrii-suse/environs
+# when we build image we don't know user id who will use it
+# so make folder writeble for everyone inside container
+RUN chmod -R o+w environs
 
 WORKDIR /opt/environs
 RUN bash -x .product/mb/branch/.install_dependencies.sh


### PR DESCRIPTION
Previous implementation did try to insert zsums using hex representation, which did
result for huge files in memory allocation bigger than 1G and led to memory errors.

Fixes https://github.com/openSUSE/mirrorbrain/issues/22