### PR TITLE
Parametrize zsync block size for huge files

### DIFF
--- a/mb/scripts/mb
+++ b/mb/scripts/mb
@@ -1158,7 +1158,9 @@ class MirrorDoctor(cmdln.Cmdln):
                                                         'chunked_hashes'),
                                                     chunk_size=chunk_size,
                                                     do_chunked_with_zsync=do_chunked_with_zsync,
-                                                    skip_metadata=skip_metadata)
+                                                    skip_metadata=skip_metadata,
+                                                    zsync_block_size_for_1G=self.config.dbconfig.get(
+                                                        'zsync_block_size_for_1G'))
                 except OSError as e:
                     if e.errno == errno.ENOENT:
                         sys.stderr.write('File vanished: %r\n' % src)

--- a/mb/tests/conf_tests.py
+++ b/mb/tests/conf_tests.py
@@ -1,0 +1,22 @@
+import unittest
+
+from mb.conf import adjust_zsync_block_size_for_1G
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_adjust_zsync_block_size_for_1G(self):
+        cases = {
+            0: None,
+            1023: None,
+            1025: 1024,
+            3*1024: 2*1024,
+            4*1024: 4*1024,
+            4*1024+1: 4*1024,
+            1024*1024*1024+1: 1024*1024*1024
+        }
+        for n in cases:
+            self.assertEqual(cases[n], adjust_zsync_block_size_for_1G(n), "for input " + repr(n))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to https://github.com/openSUSE/mirrorbrain/issues/22
With fix from #46 with 200G files on local environs tests: 
BIG_FILE_SIZE=200G REBUILD=1 bash -x mirrorbrain/t/docker/environs/07-zsync.sh 
(second run is adding following parameters in the test script )
```
sed -i '/dbname = mirrorbrain/a zsync_hashes = 1\nchunk_size = 33554432\nzsync_block_size_for_1G = 1048576' mb9*/mirrorbrain.conf
```

```
chunk_size    |  zsync_block_size_for_1G  |  RAM usage  |  CPU time sec
-----------------------------------------------------------------------------------------------
default (256K)|  default  (4Kb)           |   5.864g    |     35:33
32M           |  1M                       |   100M      |     32:56
```
